### PR TITLE
Added support for modifiers

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,7 +94,8 @@
             "mixins",
             "utils",
             "serializers",
-            "adapters"
+            "adapters",
+            "modifiers"
           ]
         },
         "fileHopper.testSubRootFolders": {


### PR DESCRIPTION
##Summary
Ember modifiers will be created under modifiers folder. Added modifiers path to `appSubfolders` so that it will be possible for users to hop between test cases and the modifier file in itself.

##Screenshots
<img width="1034" alt="Screen Shot 2022-04-06 at 4 50 53 PM" src="https://user-images.githubusercontent.com/792903/162129622-18d67850-b25c-43f6-835e-7b655f04bb9c.png">
<img width="1035" alt="Screen Shot 2022-04-06 at 4 51 06 PM" src="https://user-images.githubusercontent.com/792903/162129635-b653680d-c018-488c-a385-26353a672701.png">

